### PR TITLE
refactor: switch entity ids to uuid

### DIFF
--- a/src/main/java/com/instar/common/filter/JwtAuthFilter.java
+++ b/src/main/java/com/instar/common/filter/JwtAuthFilter.java
@@ -22,6 +22,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
@@ -47,7 +48,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             throws IOException, ServletException {
         System.out.println(request.getRequestURI());
         String token = null;
-        String userId = null;
+        UUID userId = null;
 
         String path = request.getRequestURI();
         if (EXCLUDED_PATHS.contains(path)) {

--- a/src/main/java/com/instar/common/util/CurrentUserUtil.java
+++ b/src/main/java/com/instar/common/util/CurrentUserUtil.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Component
 @RequiredArgsConstructor
 public class CurrentUserUtil {
@@ -24,7 +26,7 @@ public class CurrentUserUtil {
         return null;
     }
 
-    public static String getCurrentUserId() {
+    public static UUID getCurrentUserId() {
         CustomUserDetails user = getCurrentUser();
         return user != null ? user.getId() : null;
     }
@@ -37,7 +39,7 @@ public class CurrentUserUtil {
     }
 
     public User getUser() {
-        String userId = getCurrentUserId();
+        UUID userId = getCurrentUserId();
         return userId != null ? userRepository.findById(userId).orElse(null) : null;
     }
 }

--- a/src/main/java/com/instar/common/util/JwtUtil.java
+++ b/src/main/java/com/instar/common/util/JwtUtil.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtUtil {
@@ -26,9 +27,9 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(SECRET.getBytes()); //HMAC phương pháp xác thực dữ liệu
     }
 
-    public String createToken(String username, String userId, String role) {
+    public String createToken(String username, UUID userId, String role) {
         return Jwts.builder()
-                .setSubject(userId)
+                .setSubject(userId.toString())
                 .setIssuer("instar")
                 .claim("username", username)
                 .claim("role", role)
@@ -78,13 +79,14 @@ public class JwtUtil {
     }
 
     // mặc định lấy key sub trong payload
-    public String extractUserId(String token) {
-        return Jwts.parserBuilder()
+    public UUID extractUserId(String token) {
+        String id = Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
+        return UUID.fromString(id);
     }
 
     public String extractUsername(String token) {

--- a/src/main/java/com/instar/config/security/CustomUserDetails.java
+++ b/src/main/java/com/instar/config/security/CustomUserDetails.java
@@ -7,13 +7,14 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.UUID;
 
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 public class CustomUserDetails implements UserDetails {
-    private String id;
+    private UUID id;
     private String username;
     private String password;
     private boolean enabled;

--- a/src/main/java/com/instar/feature/auth/AuthResponse.java
+++ b/src/main/java/com/instar/feature/auth/AuthResponse.java
@@ -1,5 +1,6 @@
 package com.instar.feature.auth;
 import lombok.*;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
@@ -14,7 +15,7 @@ public class AuthResponse {
     @AllArgsConstructor
     @Builder
     public static class User {
-        private String id;
+        private UUID id;
         private String username;
         private String email;
         private String fullName;

--- a/src/main/java/com/instar/feature/auth/AuthServiceImpl.java
+++ b/src/main/java/com/instar/feature/auth/AuthServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -61,7 +62,7 @@ public class AuthServiceImpl implements AuthService {
 
         deviceRepository.save(device);
 
-        String token = jwtUtil.createToken(user.getUsername(), String.valueOf(user.getId()), user.getRole());
+        String token = jwtUtil.createToken(user.getUsername(), user.getId(), user.getRole());
         long expiresIn = jwtUtil.getExpiration();
 
         AuthResponse.User dto = AuthResponse.User.builder()
@@ -101,7 +102,7 @@ public class AuthServiceImpl implements AuthService {
     public ResponseEntity<?> logout(String token, HttpServletResponse response) {
         if (token != null && jwtUtil.validateToken(token)) {
             // Lấy userId từ token
-            String userId = jwtUtil.extractUserId(token);
+            UUID userId = jwtUtil.extractUserId(token);
 
             // Cập nhật device isActive = false
             deviceRepository.findAllByUserId(userId).forEach(device -> {

--- a/src/main/java/com/instar/feature/chat/MessageController.java
+++ b/src/main/java/com/instar/feature/chat/MessageController.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/messages")
@@ -47,7 +48,7 @@ public class MessageController {
 
     @PostMapping("/send")
     public ResponseEntity<?> sendMessageWithFiles(
-            @RequestParam("chatId") String chatId,
+            @RequestParam("chatId") UUID chatId,
             @RequestParam("content") String content,
             @RequestPart(value = "files", required = false) MultipartFile[] files,
             HttpServletRequest request
@@ -56,7 +57,7 @@ public class MessageController {
         if (token == null || !jwtUtil.validateToken(token))
             return ResponseEntity.status(401).body("Unauthorized");
 
-        String userId = jwtUtil.extractUserId(token);
+        UUID userId = jwtUtil.extractUserId(token);
         User sender = userRepository.findById(userId).orElse(null);
         Chat chat = chatRepository.findById(chatId).orElse(null);
 

--- a/src/main/java/com/instar/feature/chat/dto/ChatDto.java
+++ b/src/main/java/com/instar/feature/chat/dto/ChatDto.java
@@ -4,13 +4,14 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 public class ChatDto {
-    private String id;
+    private UUID id;
     private String chatName;
     private Boolean isGroup;
-    private String createdById;
+    private UUID createdById;
     private LocalDateTime createdAt;
-    private List<String> memberIds; // danh sách user id trong nhóm
+    private List<UUID> memberIds; // danh sách user id trong nhóm
 }

--- a/src/main/java/com/instar/feature/chat/dto/ChatUserDto.java
+++ b/src/main/java/com/instar/feature/chat/dto/ChatUserDto.java
@@ -5,12 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ChatUserDto {
-    private String chatId;
-    private String userId;
+    private UUID chatId;
+    private UUID userId;
     private Boolean isAdmin;
 }

--- a/src/main/java/com/instar/feature/chat/dto/MessageAttachmentDto.java
+++ b/src/main/java/com/instar/feature/chat/dto/MessageAttachmentDto.java
@@ -5,13 +5,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class MessageAttachmentDto {
-    private String id;
-    private String messageId;
+    private UUID id;
+    private UUID messageId;
     private String fileUrl;
     private String fileType;
 }

--- a/src/main/java/com/instar/feature/chat/dto/MessageDto.java
+++ b/src/main/java/com/instar/feature/chat/dto/MessageDto.java
@@ -7,15 +7,16 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class MessageDto {
-    private String id;
-    private String chatId;
-    private String senderId;
+    private UUID id;
+    private UUID chatId;
+    private UUID senderId;
     private String content;
     private LocalDateTime createdAt;
     private Boolean isRead;

--- a/src/main/java/com/instar/feature/chat/entity/Chat.java
+++ b/src/main/java/com/instar/feature/chat/entity/Chat.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 @Entity
 @Data
 @NoArgsConstructor
@@ -17,8 +18,9 @@ import java.util.List;
 @Table(name = "chats")
 public class Chat {
     @Id
-    @Column(length = 36, nullable = false, updatable = false)
-    private String id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false, columnDefinition = "uniqueidentifier")
+    private UUID id;
 
     @Column(name = "chat_name", length = 100)
     private String chatName;

--- a/src/main/java/com/instar/feature/chat/entity/ChatUserId.java
+++ b/src/main/java/com/instar/feature/chat/entity/ChatUserId.java
@@ -18,14 +18,15 @@ package com.instar.feature.chat.entity;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.UUID;
 
 public class ChatUserId implements Serializable {
-    private String chat;
-    private String user;
+    private UUID chat;
+    private UUID user;
 
     public ChatUserId() {}
 
-    public ChatUserId(String chat, String user) {
+    public ChatUserId(UUID chat, UUID user) {
         this.chat = chat;
         this.user = user;
     }

--- a/src/main/java/com/instar/feature/chat/entity/Message.java
+++ b/src/main/java/com/instar/feature/chat/entity/Message.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 @Entity
 @Data
 @NoArgsConstructor
@@ -16,8 +17,9 @@ import java.time.LocalDateTime;
 @Table(name = "messages")
 public class Message {
     @Id
-    @Column(length = 36, nullable = false, updatable = false)
-    private String id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false, columnDefinition = "uniqueidentifier")
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "chat_id", nullable = false)

--- a/src/main/java/com/instar/feature/chat/entity/MessageAttachment.java
+++ b/src/main/java/com/instar/feature/chat/entity/MessageAttachment.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Entity
 @Data
 @NoArgsConstructor
@@ -14,8 +16,9 @@ import lombok.NoArgsConstructor;
 @Table(name = "message_attachments")
 public class MessageAttachment {
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", columnDefinition = "uniqueidentifier")
-    private String id;
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "message_id", nullable = false)

--- a/src/main/java/com/instar/feature/chat/mapper/ChatMapper.java
+++ b/src/main/java/com/instar/feature/chat/mapper/ChatMapper.java
@@ -6,6 +6,7 @@ import com.instar.feature.chat.entity.ChatUser;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Component
@@ -19,7 +20,7 @@ public class ChatMapper {
         dto.setCreatedById(chat.getCreatedBy() != null ? chat.getCreatedBy().getId() : null);
 
         // Lấy danh sách user id từ chatUsers
-        List<String> memberIds = chat.getChatUsers() != null
+        List<UUID> memberIds = chat.getChatUsers() != null
                 ? chat.getChatUsers().stream()
                 .map(ChatUser::getUser)
                 .map(user -> user.getId())

--- a/src/main/java/com/instar/feature/chat/repository/ChatRepository.java
+++ b/src/main/java/com/instar/feature/chat/repository/ChatRepository.java
@@ -2,6 +2,7 @@ package com.instar.feature.chat.repository;
 
 import com.instar.feature.chat.entity.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
 
-public interface ChatRepository extends JpaRepository<Chat, String> {
+public interface ChatRepository extends JpaRepository<Chat, UUID> {
 }

--- a/src/main/java/com/instar/feature/chat/repository/ChatUserRepository.java
+++ b/src/main/java/com/instar/feature/chat/repository/ChatUserRepository.java
@@ -5,8 +5,9 @@ import com.instar.feature.chat.entity.ChatUserId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface ChatUserRepository extends JpaRepository<ChatUser, ChatUserId> {
-    List<ChatUser> findByUserId(String userId);
-    List<ChatUser> findByChatId(String chatId);
+    List<ChatUser> findByUserId(UUID userId);
+    List<ChatUser> findByChatId(UUID chatId);
 }

--- a/src/main/java/com/instar/feature/chat/repository/MessageAttachmentRepository.java
+++ b/src/main/java/com/instar/feature/chat/repository/MessageAttachmentRepository.java
@@ -4,7 +4,8 @@ import com.instar.feature.chat.entity.MessageAttachment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.UUID;
 
-public interface MessageAttachmentRepository extends JpaRepository<MessageAttachment, String> {
-    List<MessageAttachment> findByMessageId(String messageId);
+public interface MessageAttachmentRepository extends JpaRepository<MessageAttachment, UUID> {
+    List<MessageAttachment> findByMessageId(UUID messageId);
 }

--- a/src/main/java/com/instar/feature/chat/repository/MessageRepository.java
+++ b/src/main/java/com/instar/feature/chat/repository/MessageRepository.java
@@ -4,7 +4,8 @@ import com.instar.feature.chat.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.UUID;
 
-public interface MessageRepository extends JpaRepository<Message, String> {
-    List<Message> findByChatIdOrderByCreatedAtAsc(String chatId);
+public interface MessageRepository extends JpaRepository<Message, UUID> {
+    List<Message> findByChatIdOrderByCreatedAtAsc(UUID chatId);
 }

--- a/src/main/java/com/instar/feature/chat/service/ChatService.java
+++ b/src/main/java/com/instar/feature/chat/service/ChatService.java
@@ -1,9 +1,10 @@
 package com.instar.feature.chat.service;
 import com.instar.feature.chat.dto.ChatDto;
 import java.util.List;
+import java.util.UUID;
 
 public interface ChatService {
-    ChatDto createGroup(String chatName, String creatorId, List<String> memberIds);
-    List<ChatDto> getUserChats(String userId);
-    void addUserToGroup(String chatId, String userId, boolean isAdmin);
+    ChatDto createGroup(String chatName, UUID creatorId, List<UUID> memberIds);
+    List<ChatDto> getUserChats(UUID userId);
+    void addUserToGroup(UUID chatId, UUID userId, boolean isAdmin);
 }

--- a/src/main/java/com/instar/feature/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/instar/feature/chat/service/ChatServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -25,7 +26,7 @@ public class ChatServiceImpl implements ChatService {
     private final ChatMapper chatMapper;
 
     @Override
-    public ChatDto createGroup(String chatName, String creatorId, List<String> memberIds) {
+    public ChatDto createGroup(String chatName, UUID creatorId, List<UUID> memberIds) {
         User creator = userRepository.findById(creatorId).orElse(null);
         if (creator == null) throw new NoPermissionException();
 
@@ -40,7 +41,7 @@ public class ChatServiceImpl implements ChatService {
         ChatUser adminUser = ChatUser.builder().chat(chat).user(creator).isAdmin(true).build();
         chatUserRepository.save(adminUser);
 
-        for (String userId : memberIds) {
+        for (UUID userId : memberIds) {
             if (!userId.equals(creatorId)) {
                 User member = userRepository.findById(userId).orElse(null);
                 if (member != null) {
@@ -53,7 +54,7 @@ public class ChatServiceImpl implements ChatService {
     }
 
     @Override
-    public List<ChatDto> getUserChats(String userId) {
+    public List<ChatDto> getUserChats(UUID userId) {
         List<ChatUser> chatUsers = chatUserRepository.findByUserId(userId);
         return chatUsers.stream()
                 .map(chatUser -> chatMapper.toDto(chatUser.getChat()))
@@ -61,7 +62,7 @@ public class ChatServiceImpl implements ChatService {
     }
 
     @Override
-    public void addUserToGroup(String chatId, String userId, boolean isAdmin) {
+    public void addUserToGroup(UUID chatId, UUID userId, boolean isAdmin) {
         Chat chat = chatRepository.findById(chatId).orElse(null);
         User user = userRepository.findById(userId).orElse(null);
         if (chat == null || user == null) throw new NoPermissionException();

--- a/src/main/java/com/instar/feature/chat/service/MessageAttachmentService.java
+++ b/src/main/java/com/instar/feature/chat/service/MessageAttachmentService.java
@@ -2,9 +2,10 @@ package com.instar.feature.chat.service;
 import com.instar.feature.chat.dto.MessageAttachmentDto;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface MessageAttachmentService {
     MessageAttachmentDto add(MessageAttachmentDto dto);
-    List<MessageAttachmentDto> findByMessageId(String messageId);
-    void delete(String id);
+    List<MessageAttachmentDto> findByMessageId(UUID messageId);
+    void delete(UUID id);
 }

--- a/src/main/java/com/instar/feature/chat/service/MessageAttachmentServiceImpl.java
+++ b/src/main/java/com/instar/feature/chat/service/MessageAttachmentServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,13 +31,13 @@ public class MessageAttachmentServiceImpl implements MessageAttachmentService {
     }
 
     @Override
-    public List<MessageAttachmentDto> findByMessageId(String messageId) {
+    public List<MessageAttachmentDto> findByMessageId(UUID messageId) {
         return messageAttachmentRepository.findByMessageId(messageId)
                 .stream().map(messageAttachmentMapper::toDto).collect(Collectors.toList());
     }
 
     @Override
-    public void delete(String id) {
+    public void delete(UUID id) {
         messageAttachmentRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/instar/feature/chat/service/MessageService.java
+++ b/src/main/java/com/instar/feature/chat/service/MessageService.java
@@ -4,9 +4,10 @@ package com.instar.feature.chat.service;
 import com.instar.feature.chat.dto.MessageDto;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface MessageService {
-    List<MessageDto> getConversations(String userId);
+    List<MessageDto> getConversations(UUID chatId);
     MessageDto save(MessageDto dto);
-    void markRead(String messageId);
+    void markRead(UUID messageId);
 }

--- a/src/main/java/com/instar/feature/chat/service/MessageServiceImpl.java
+++ b/src/main/java/com/instar/feature/chat/service/MessageServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -50,7 +51,7 @@ public class MessageServiceImpl implements MessageService {
     }
 
     @Override
-    public List<MessageDto> getConversations(String chatId) {
+    public List<MessageDto> getConversations(UUID chatId) {
         Chat chat = chatRepository.findById(chatId).orElse(null);
         if (chat == null) throw new NoPermissionException();
         return messageRepository.findByChatIdOrderByCreatedAtAsc(chatId)
@@ -58,9 +59,9 @@ public class MessageServiceImpl implements MessageService {
     }
 
     @Override
-    public void markRead(String messageId) {
+    public void markRead(UUID messageId) {
         Message e = messageRepository.findById(messageId).orElse(null);
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (e == null) throw new NoPermissionException();
         e.setIsRead(true);

--- a/src/main/java/com/instar/feature/device/Device.java
+++ b/src/main/java/com/instar/feature/device/Device.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Data
@@ -16,8 +17,9 @@ import java.time.LocalDateTime;
 @Table(name = "Devices")
 public class Device {
     @Id
-    @Column(length = 36, nullable = false, updatable = false)
-    private String id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false, columnDefinition = "uniqueidentifier")
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(nullable = false)

--- a/src/main/java/com/instar/feature/device/DeviceController.java
+++ b/src/main/java/com/instar/feature/device/DeviceController.java
@@ -2,6 +2,7 @@ package com.instar.feature.device;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/devices")
@@ -11,7 +12,7 @@ public class DeviceController {
     private final DeviceRepository deviceRepository;
 
     @GetMapping("/user/{userId}")
-    public List<Device> getDevices(@PathVariable String userId) {
+    public List<Device> getDevices(@PathVariable UUID userId) {
         return deviceRepository.findAll()
                 .stream()
                 .filter(d -> d.getUser().getId().equals(userId))
@@ -24,7 +25,7 @@ public class DeviceController {
     }
 
     @DeleteMapping("/{id}")
-    public String remove(@PathVariable String id) {
+    public String remove(@PathVariable UUID id) {
         deviceRepository.deleteById(id);
         return "Đã xóa thiết bị";
     }

--- a/src/main/java/com/instar/feature/device/DeviceRepository.java
+++ b/src/main/java/com/instar/feature/device/DeviceRepository.java
@@ -2,8 +2,9 @@ package com.instar.feature.device;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface DeviceRepository extends JpaRepository<Device, String> {
-    Optional<Device> findByUserIdAndFingerprint(String userId, String fingerprint);
-    List<Device> findAllByUserId(String userId);
+public interface DeviceRepository extends JpaRepository<Device, UUID> {
+    Optional<Device> findByUserIdAndFingerprint(UUID userId, String fingerprint);
+    List<Device> findAllByUserId(UUID userId);
 }

--- a/src/main/java/com/instar/feature/notification/Notification.java
+++ b/src/main/java/com/instar/feature/notification/Notification.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Data
@@ -16,8 +17,9 @@ import java.time.LocalDateTime;
 @Table(name = "Notifications")
 public class Notification {
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", columnDefinition = "uniqueidentifier")
-    private String id;
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(nullable = false)

--- a/src/main/java/com/instar/feature/notification/NotificationController.java
+++ b/src/main/java/com/instar/feature/notification/NotificationController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -12,12 +13,12 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping("/user/{userId}")
-    public List<NotificationDto> getNotifications(@PathVariable String userId) {
+    public List<NotificationDto> getNotifications(@PathVariable UUID userId) {
         return notificationService.findByUserId(userId);
     }
 
     @PutMapping("/{id}/read")
-    public String markRead(@PathVariable String id) {
+    public String markRead(@PathVariable UUID id) {
         notificationService.markRead(id);
         return "Đã đọc thông báo";
     }

--- a/src/main/java/com/instar/feature/notification/NotificationDto.java
+++ b/src/main/java/com/instar/feature/notification/NotificationDto.java
@@ -6,14 +6,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class NotificationDto {
-    private String id;
-    private String userId;
+    private UUID id;
+    private UUID userId;
     private String type;
     private String message;
     private String link;

--- a/src/main/java/com/instar/feature/notification/NotificationRepository.java
+++ b/src/main/java/com/instar/feature/notification/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.instar.feature.notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
 
-public interface NotificationRepository extends JpaRepository<Notification, String> {
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
 }

--- a/src/main/java/com/instar/feature/notification/NotificationService.java
+++ b/src/main/java/com/instar/feature/notification/NotificationService.java
@@ -1,8 +1,9 @@
 package com.instar.feature.notification;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface NotificationService {
-    List<NotificationDto> findByUserId(String userId);
-    void markRead(String notificationId);
+    List<NotificationDto> findByUserId(UUID userId);
+    void markRead(UUID notificationId);
 }

--- a/src/main/java/com/instar/feature/notification/NotificationServiceImpl.java
+++ b/src/main/java/com/instar/feature/notification/NotificationServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -15,8 +16,8 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationMapper notificationMapper;
 
     @Override
-    public List<NotificationDto> findByUserId(String userId) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+    public List<NotificationDto> findByUserId(UUID userId) {
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (!userId.equals(currentUserId) && !admin) {
             throw new NoPermissionException();
@@ -28,9 +29,9 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    public void markRead(String notificationId) {
+    public void markRead(UUID notificationId) {
         Notification n = notificationRepository.findById(notificationId).orElse(null);
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (n == null || (!n.getUser().getId().equals(currentUserId) && !admin)) {
             throw new NoPermissionException();

--- a/src/main/java/com/instar/feature/user/User.java
+++ b/src/main/java/com/instar/feature/user/User.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
@@ -15,8 +16,9 @@ import java.time.LocalDateTime;
 @Table(name = "Users")
 public class User {
     @Id
-    @Column(length = 36, nullable = false, updatable = false)
-    private String id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false, columnDefinition = "uniqueidentifier")
+    private UUID id;
 
     @Column(unique = true, nullable = false, length = 50)
     private String username;

--- a/src/main/java/com/instar/feature/user/UserController.java
+++ b/src/main/java/com/instar/feature/user/UserController.java
@@ -3,6 +3,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/users")
@@ -12,7 +13,7 @@ public class UserController {
     private final UserRepository userRepository;
 
     @GetMapping("/{id}")
-    public UserDto getUser(@PathVariable String id) {
+    public UserDto getUser(@PathVariable UUID id) {
         return userService.findById(id);
     }
 
@@ -22,20 +23,20 @@ public class UserController {
     }
 
     @PutMapping("/{id}")
-    public UserDto updateUser(@PathVariable String id, @RequestBody UserDto dto) {
+    public UserDto updateUser(@PathVariable UUID id, @RequestBody UserDto dto) {
         return userService.update(id, dto);
     }
 
 
     @PutMapping("/{id}/password")
-    public String changePassword(@PathVariable String id, @RequestBody ChangePasswordRequestDto req) {
+    public String changePassword(@PathVariable UUID id, @RequestBody ChangePasswordRequestDto req) {
         userService.changePassword(id, req.getOldPassword(), req.getNewPassword());
         return "Đổi mật khẩu thành công";
     }
 
 
     @PostMapping("/{id}/verify")
-    public String verify(@PathVariable String id, @RequestParam String code) {
+    public String verify(@PathVariable UUID id, @RequestParam String code) {
         userService.verifyAccount(id, code);
         return "Kích hoạt tài khoản thành công";
     }

--- a/src/main/java/com/instar/feature/user/UserDto.java
+++ b/src/main/java/com/instar/feature/user/UserDto.java
@@ -8,13 +8,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UserDto {
-    private String id;
+    private UUID id;
 //    @UniqueUsername
     private String username;
 //    @UniqueEmail

--- a/src/main/java/com/instar/feature/user/UserRepository.java
+++ b/src/main/java/com/instar/feature/user/UserRepository.java
@@ -1,7 +1,8 @@
 package com.instar.feature.user;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<User, String> {
+public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/instar/feature/user/UserService.java
+++ b/src/main/java/com/instar/feature/user/UserService.java
@@ -1,13 +1,14 @@
 package com.instar.feature.user;
 import java.util.List;
+import java.util.UUID;
 
 public interface UserService {
-    UserDto findById(String id);
+    UserDto findById(UUID id);
     UserDto create(UserDto userDto);
-    UserDto update(String id, UserDto userDto);
-    void delete(String id);
+    UserDto update(UUID id, UserDto userDto);
+    void delete(UUID id);
     List<User> findAll();
     UserDto findByUsername(String username);
-    void changePassword(String id, String oldPassword, String newPassword);
-    void verifyAccount(String id, String code);
+    void changePassword(UUID id, String oldPassword, String newPassword);
+    void verifyAccount(UUID id, String code);
 }

--- a/src/main/java/com/instar/feature/user/UserServiceImpl.java
+++ b/src/main/java/com/instar/feature/user/UserServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +18,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public UserDto findById(String id) {
+    public UserDto findById(UUID id) {
         return userRepository.findById(id)
                 .map(userMapper::toDto)
                 .orElse(null);
@@ -35,8 +36,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserDto update(String id, UserDto dto) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+    public UserDto update(UUID id, UserDto dto) {
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (!id.equals(currentUserId) && !admin) {
             throw new NoPermissionException();
@@ -55,8 +56,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void delete(String id) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+    public void delete(UUID id) {
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (!id.equals(currentUserId) && !admin) {
             throw new NoPermissionException();
@@ -76,7 +77,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserDto findByUsername(String username) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         User user = userRepository.findAll().stream()
                 .filter(u -> u.getUsername().equals(username))
@@ -90,8 +91,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void changePassword(String id, String oldPassword, String newPassword) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+    public void changePassword(UUID id, String oldPassword, String newPassword) {
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (!id.equals(currentUserId) && !admin) {
             throw new NoPermissionException();
@@ -104,8 +105,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void verifyAccount(String id, String code) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+    public void verifyAccount(UUID id, String code) {
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (!id.equals(currentUserId) && !admin) {
             throw new NoPermissionException();

--- a/src/main/java/com/instar/feature/userBehavior/UserBehavior.java
+++ b/src/main/java/com/instar/feature/userBehavior/UserBehavior.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
@@ -16,8 +17,9 @@ import java.time.LocalDateTime;
 @Table(name = "userBehaviors")
 public class UserBehavior {
     @Id
-    @Column(length = 36, nullable = false, updatable = false)
-    private String id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false, columnDefinition = "uniqueidentifier")
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(nullable = false)
@@ -26,8 +28,8 @@ public class UserBehavior {
     @Column(nullable = false)
     private String action;
 
-    @Column(nullable = false)
-    private String targetId;
+    @Column(nullable = false, columnDefinition = "uniqueidentifier")
+    private UUID targetId;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/instar/feature/userBehavior/UserBehaviorController.java
+++ b/src/main/java/com/instar/feature/userBehavior/UserBehaviorController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/user-behaviors")
@@ -17,7 +18,7 @@ public class UserBehaviorController {
     }
 
     @GetMapping("/user/{userId}")
-    public List<UserBehaviorDto> getByUser(@PathVariable String userId) {
+    public List<UserBehaviorDto> getByUser(@PathVariable UUID userId) {
         return userBehaviorService.findByUserId(userId);
     }
 }

--- a/src/main/java/com/instar/feature/userBehavior/UserBehaviorDto.java
+++ b/src/main/java/com/instar/feature/userBehavior/UserBehaviorDto.java
@@ -4,15 +4,16 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UserBehaviorDto {
-    private String id;
-    private String userId;
+    private UUID id;
+    private UUID userId;
     private String action;
-    private String targetId;
+    private UUID targetId;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/instar/feature/userBehavior/UserBehaviorRepository.java
+++ b/src/main/java/com/instar/feature/userBehavior/UserBehaviorRepository.java
@@ -1,5 +1,6 @@
 package com.instar.feature.userBehavior;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
 
-public interface UserBehaviorRepository extends JpaRepository<UserBehavior, String> {
+public interface UserBehaviorRepository extends JpaRepository<UserBehavior, UUID> {
 }

--- a/src/main/java/com/instar/feature/userBehavior/UserBehaviorService.java
+++ b/src/main/java/com/instar/feature/userBehavior/UserBehaviorService.java
@@ -1,7 +1,8 @@
 package com.instar.feature.userBehavior;
 import java.util.List;
+import java.util.UUID;
 
 public interface UserBehaviorService {
     UserBehaviorDto logBehavior(UserBehaviorDto behaviorDto);
-    List<UserBehaviorDto> findByUserId(String userId);
+    List<UserBehaviorDto> findByUserId(UUID userId);
 }

--- a/src/main/java/com/instar/feature/userBehavior/UserBehaviorServiceImpl.java
+++ b/src/main/java/com/instar/feature/userBehavior/UserBehaviorServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,7 +20,7 @@ public class UserBehaviorServiceImpl implements UserBehaviorService {
 
     @Override
     public UserBehaviorDto logBehavior(UserBehaviorDto dto) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (!dto.getUserId().equals(currentUserId) && !admin) {
             throw new NoPermissionException();
@@ -31,8 +32,8 @@ public class UserBehaviorServiceImpl implements UserBehaviorService {
     }
 
     @Override
-    public List<UserBehaviorDto> findByUserId(String userId) {
-        String currentUserId = CurrentUserUtil.getCurrentUserId();
+    public List<UserBehaviorDto> findByUserId(UUID userId) {
+        UUID currentUserId = CurrentUserUtil.getCurrentUserId();
         boolean admin = CurrentUserUtil.isAdmin();
         if (!userId.equals(currentUserId) && !admin) {
             throw new NoPermissionException();


### PR DESCRIPTION
## Summary
- migrate all entity identifier fields to `UUID`
- adjust repositories, services, controllers and security utilities to use `UUID`
- update JWT helper to emit and parse UUID-based user ids

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a836a3f158832da8f295dc0960d033