### PR TITLE
feat: simplify chat feature and test page

### DIFF
--- a/src/main/java/com/instar/feature/chat/ChatRestController.java
+++ b/src/main/java/com/instar/feature/chat/ChatRestController.java
@@ -1,0 +1,45 @@
+package com.instar.feature.chat;
+
+import com.instar.common.util.JwtUtil;
+import com.instar.feature.chat.dto.ChatDto;
+import com.instar.feature.chat.service.ChatService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+public class ChatRestController {
+    private final ChatService chatService;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/group")
+    public ResponseEntity<?> createGroup(@RequestParam String chatName,
+                                         @RequestParam List<UUID> memberIds,
+                                         HttpServletRequest request) {
+        String token = jwtUtil.getToken(request);
+        if (token == null || !jwtUtil.validateToken(token)) {
+            return ResponseEntity.status(401).body("Unauthorized");
+        }
+        UUID creatorId = jwtUtil.extractUserId(token);
+        ChatDto dto = chatService.createGroup(chatName, creatorId, memberIds);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping("/private")
+    public ResponseEntity<?> createPrivate(@RequestParam UUID partnerId,
+                                           HttpServletRequest request) {
+        String token = jwtUtil.getToken(request);
+        if (token == null || !jwtUtil.validateToken(token)) {
+            return ResponseEntity.status(401).body("Unauthorized");
+        }
+        UUID userId = jwtUtil.extractUserId(token);
+        ChatDto dto = chatService.createPrivateChat(userId, partnerId);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/instar/feature/chat/service/ChatService.java
+++ b/src/main/java/com/instar/feature/chat/service/ChatService.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public interface ChatService {
     ChatDto createGroup(String chatName, UUID creatorId, List<UUID> memberIds);
+    ChatDto createPrivateChat(UUID userId1, UUID userId2);
     List<ChatDto> getUserChats(UUID userId);
     void addUserToGroup(UUID chatId, UUID userId, boolean isAdmin);
 }

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -15,6 +15,17 @@
 <div id="status"></div>
 
 <hr>
+<!-- Tạo Chat -->
+<div>
+    <input type="text" id="partnerId" placeholder="Partner ID"/>
+    <button onclick="createPrivateChat()">Chat Riêng</button>
+    <br>
+    <input type="text" id="groupName" placeholder="Tên nhóm"/>
+    <input type="text" id="groupMemberIds" placeholder="IDs thành viên, cách nhau dấu phẩy"/>
+    <button onclick="createGroupChat()">Tạo Nhóm</button>
+</div>
+
+<hr>
 <!-- Chat -->
 <input type="text" id="chatId" value="1"/>
 <input type="text" id="msg" placeholder="Tin nhắn"/>
@@ -27,7 +38,8 @@
 
 <hr>
 <!-- Call -->
-<button onclick="startCall()">Start Call</button>
+<button onclick="startVideoCall()">Video Call</button>
+<button onclick="startAudioCall()">Audio Call</button>
 <button onclick="hangup()">Hangup</button>
 <br>
 <video id="localVideo" autoplay muted playsinline style="width:200px;border:1px solid black"></video>
@@ -37,6 +49,8 @@
     let stompClient = null;
     let currentUser = null;
     let pc = null;
+    let callWithVideo = true;
+    let chatSubscription = null;
 
     // LOGIN
     async function login(username, password) {
@@ -63,20 +77,34 @@
         stompClient.connect({}, frame => {
             console.log("CONNECTED:", frame);
 
-            // Sub chat
-            const chatId = document.getElementById("chatId").value;
-            const dest = "/topic/chat/" + chatId + "/user/" + currentUser.id;
-            stompClient.subscribe(dest, msg => {
-                const m = JSON.parse(msg.body);
-                document.getElementById("messages").innerHTML +=
-                    "<div><b>"+(m.sender?.username||"")+"</b>: "+m.content+"</div>";
-            });
+            subscribeChat();
 
             // Sub call
             stompClient.subscribe("/topic/call", msg => {
                 const data = JSON.parse(msg.body);
                 if (data.from !== currentUser.username) handleSignal(data);
             });
+        });
+    }
+
+    function subscribeChat(){
+        if (!stompClient) return;
+        if (chatSubscription) chatSubscription.unsubscribe();
+        const chatId = document.getElementById("chatId").value;
+        const dest = "/topic/chat/" + chatId + "/user/" + currentUser.id;
+        chatSubscription = stompClient.subscribe(dest, msg => {
+            const m = JSON.parse(msg.body);
+            let html = "<div><b>"+(m.sender?.username||"")+"</b>: "+m.content;
+            if (m.attachments) {
+                m.attachments.forEach(a => {
+                    const url = "/uploads/" + a.fileUrl;
+                    if (a.fileType === "image") html += `<div><img src="${url}" width="100"/></div>`;
+                    else if (a.fileType === "video") html += `<div><video src="${url}" width="100" controls></video></div>`;
+                    else html += `<div><a href="${url}" target="_blank">${a.fileUrl}</a></div>`;
+                });
+            }
+            html += "</div>";
+            document.getElementById("messages").innerHTML += html;
         });
     }
 
@@ -92,6 +120,42 @@
             body: form,
             credentials: "include"
         });
+    }
+
+    // CREATE PRIVATE CHAT
+    async function createPrivateChat(){
+        const partnerId = document.getElementById("partnerId").value;
+        const form = new FormData();
+        form.append("partnerId", partnerId);
+        const res = await fetch("http://localhost:8080/api/chats/private", {
+            method: "POST",
+            body: form,
+            credentials: "include"
+        });
+        if(res.ok){
+            const data = await res.json();
+            document.getElementById("chatId").value = data.id;
+            subscribeChat();
+        }
+    }
+
+    // CREATE GROUP CHAT
+    async function createGroupChat(){
+        const name = document.getElementById("groupName").value;
+        const members = document.getElementById("groupMemberIds").value.split(",").map(s=>s.trim());
+        const form = new FormData();
+        form.append("chatName", name);
+        for (let m of members){ if(m) form.append("memberIds", m); }
+        const res = await fetch("http://localhost:8080/api/chats/group", {
+            method: "POST",
+            body: form,
+            credentials: "include"
+        });
+        if(res.ok){
+            const data = await res.json();
+            document.getElementById("chatId").value = data.id;
+            subscribeChat();
+        }
     }
 
     // SEND FILE
@@ -110,16 +174,20 @@
     }
 
     // WEBRTC CALL
-    async function startCall() {
+    function startVideoCall(){ startCall(true); }
+    function startAudioCall(){ startCall(false); }
+
+    async function startCall(withVideo) {
+        callWithVideo = withVideo;
         pc = new RTCPeerConnection();
         pc.onicecandidate = e => {
             if (e.candidate) sendSignal({type:"candidate", candidate:e.candidate});
         };
         pc.ontrack = e => remoteVideo.srcObject = e.streams[0];
 
-        const stream = await navigator.mediaDevices.getUserMedia({video:true, audio:true});
+        const stream = await navigator.mediaDevices.getUserMedia({video:withVideo, audio:true});
         stream.getTracks().forEach(t => pc.addTrack(t, stream));
-        localVideo.srcObject = stream;
+        if (withVideo) localVideo.srcObject = stream; else localVideo.srcObject = null;
 
         const offer = await pc.createOffer();
         await pc.setLocalDescription(offer);
@@ -127,15 +195,16 @@
     }
 
     async function handleSignal(msg) {
+        if (msg.video !== undefined) callWithVideo = msg.video;
         if (!pc) {
             pc = new RTCPeerConnection();
             pc.onicecandidate = e => {
                 if (e.candidate) sendSignal({type:"candidate", candidate:e.candidate});
             };
             pc.ontrack = e => remoteVideo.srcObject = e.streams[0];
-            const stream = await navigator.mediaDevices.getUserMedia({video:true, audio:true});
+            const stream = await navigator.mediaDevices.getUserMedia({video:callWithVideo, audio:true});
             stream.getTracks().forEach(t => pc.addTrack(t, stream));
-            localVideo.srcObject = stream;
+            if (callWithVideo) localVideo.srcObject = stream;
         }
 
         if (msg.type === "offer") {
@@ -152,6 +221,7 @@
 
     function sendSignal(data) {
         data.from = currentUser.username;
+        data.video = callWithVideo;
         stompClient.send("/app/call", {}, JSON.stringify(data));
     }
 


### PR DESCRIPTION
## Summary
- add REST controller to create private or group chats
- support private chat creation in `ChatService`
- expand `chat.html` to cover file sharing and audio/video calls

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a843fa1410832dba6cdef18d66d5d0